### PR TITLE
Remove oga dependency

### DIFF
--- a/fixer.gemspec
+++ b/fixer.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob('lib/**/*') + %w(LICENSE README.md)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'oga', '~> 2.0'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/lib/fixer/feed.rb
+++ b/lib/fixer/feed.rb
@@ -1,5 +1,5 @@
 require 'net/http'
-require 'oga'
+require 'rexml/document'
 
 module Fixer
   class Feed
@@ -16,9 +16,9 @@ module Fixer
     end
 
     def each
-      document.xpath('/Envelope/Cube/Cube').each do |day|
+      REXML::XPath.each(document, '//Cube/Cube[@time]') do |day|
         date = Date.parse(day.attribute('time').value)
-        day.xpath('./Cube').each do |currency|
+        REXML::XPath.each(day, './Cube') do |currency|
           yield(
             date: date,
             iso_code: currency.attribute('currency').value,
@@ -31,7 +31,7 @@ module Fixer
     private
 
     def document
-      Oga.parse_xml(xml)
+      REXML::Document.new(xml)
     end
 
     def xml

--- a/spec/feed_spec.rb
+++ b/spec/feed_spec.rb
@@ -37,5 +37,9 @@ module Fixer
       feed = Feed.new(:historical)
       feed.count.must_be :>, 33 * 3000
     end
+
+    it 'raises error with invalid type' do
+      -> { Feed.new(:invalid) }.must_raise ArgumentError
+    end
   end
 end


### PR DESCRIPTION
Ruby comes with REXML as a default XML parser, it’s much slower than oga or nokogiri but for a small library, with a non intensive use of XML parsing (most of the time the result will be stored) it should be quite enough, and it removes any external dependency.

Adding such dependency into a small (but quite handy 😄) library is sometime a big issue, most certainly with dependency like nokogiri or oga which could brings some heavy dependencies. And with projects (rails per example) which already include nokogiri, it starts to be a dependency nightmare only to parse an XML file once in a day.